### PR TITLE
Drive straight delay

### DIFF
--- a/src/main/java/org/usfirst/frc/team449/robot/drive/talonCluster/TalonClusterDrive.java
+++ b/src/main/java/org/usfirst/frc/team449/robot/drive/talonCluster/TalonClusterDrive.java
@@ -225,6 +225,7 @@ public class TalonClusterDrive extends DriveSubsystem implements NavxSubsystem {
 		leftMaster = new RotPerSecCANTalonSRX(map.getLeftMaster());
 
 		// Initialize slave talons.
+
 		for (RotPerSecCANTalonSRXMap.RotPerSecCANTalonSRX talon : map.getRightSlaveList()) {
 			RotPerSecCANTalonSRX talonObject = new RotPerSecCANTalonSRX(talon);
 			talonObject.canTalon.changeControlMode(CANTalon.TalonControlMode.Follower);

--- a/src/main/java/org/usfirst/frc/team449/robot/drive/talonCluster/commands/DefaultArcadeDrive.java
+++ b/src/main/java/org/usfirst/frc/team449/robot/drive/talonCluster/commands/DefaultArcadeDrive.java
@@ -39,6 +39,13 @@ public class DefaultArcadeDrive extends PIDAngleCommand {
 	 * The maximum velocity for the robot to be at in order to switch to driveStraight, in degrees/sec
 	 */
 	private double maxAngularVel;
+
+	private long driveStraightDelay;
+
+	private long timeAbleToDriveStraight;
+
+	private boolean delayedDriveStraight;
+
 	/**
 	 * The map of values
 	 */
@@ -58,6 +65,10 @@ public class DefaultArcadeDrive extends PIDAngleCommand {
 		this.oi = oi;
 		this.map = map;
 		driveSubsystem = drive;
+
+		timeAbleToDriveStraight = 0;
+		driveStraightDelay = (long) (map.getDriveStraightDelay() * 1000);
+		delayedDriveStraight = false;
 
 		//Needs a requires because it's a default command.
 		requires(drive);
@@ -101,12 +112,19 @@ public class DefaultArcadeDrive extends PIDAngleCommand {
 		if ((drivingStraight && rot != 0) || driveSubsystem.overrideNavX) {
 			//Switch to free drive
 			drivingStraight = false;
+			delayedDriveStraight = false;
 			System.out.println("Switching to free drive.");
 		}
 		//If we're free driving and the driver lets go of the turn stick:
-		else if (!(drivingStraight) && rot == 0 && Math.abs(driveSubsystem.navx.getRate()) <= maxAngularVel) {
+		else if (!(delayedDriveStraight) && !(drivingStraight) && rot == 0 && Math.abs(driveSubsystem.navx.getRate()) <= maxAngularVel) {
+			delayedDriveStraight = true;
+			timeAbleToDriveStraight = System.currentTimeMillis();
+		}
+
+		if(delayedDriveStraight && System.currentTimeMillis() - timeAbleToDriveStraight >= driveStraightDelay){
 			//Switch to driving straight
 			drivingStraight = true;
+			delayedDriveStraight = false;
 			//Set the setpoint to the current heading and reset the NavX
 			this.getPIDController().reset();
 			this.getPIDController().setSetpoint(subsystem.getGyroOutput());

--- a/src/main/proto/org/usfirst/frc/team449/robot/components/ToleranceBufferAnglePID.proto
+++ b/src/main/proto/org/usfirst/frc/team449/robot/components/ToleranceBufferAnglePID.proto
@@ -16,4 +16,5 @@ message ToleranceBufferAnglePID {
 	required bool deadband_enabled = 9;
 	optional double max_angular_vel = 10 [default = 180]; //Maximum angular velocity for the robot to be at to switch to driveStraight mode, in degrees/sec
 	required bool inverted = 11;
+    optional double drive_straight_delay = 12 [default = 0];
 }

--- a/src/main/resources/balbasaur_map.cfg
+++ b/src/main/resources/balbasaur_map.cfg
@@ -1,24 +1,43 @@
+
 arcade_oi {
-	gamepad: 1
-	gamepad_left_axis: 0
-	gamepad_right_axis: 5
+    gamepad: 1
+    gamepad_left_axis: 0
+    gamepad_right_axis: 5
 
-	deadband: 0.05
-	dpad_shift: 0.1
+    deadband: 0.05
+    dpad_shift: 0.1
 
-	invert_fwd: false
-	invert_rot: false
-	invert_dpad: false
+    invert_fwd: true
+    invert_rot: true
+    invert_dpad: true
 
     override_navX {
-		joystick_index: 1
-		button_index: 12
-	}
+        joystick_index: 1
+        button_index: 12
+    }
 }
 drive {
 	drive {}
 	l2r: 1
 	turn_PID {
+		PID {
+            p: 0.01
+            i: 0
+            d: 0
+            f: 0
+            percent_tolerance: 1
+		}
+        tolerance_buffer: 25
+        absolute_tolerance: 1
+        minimum_output: 0.1
+        minimum_output_enabled: true
+        maximum_output : 0
+        maximum_output_enabled: false
+        deadband: 0.75
+        deadband_enabled: true
+        inverted: false
+	}
+	straight_PID {
 		PID {
 			p: 0.01
 			i: 0
@@ -26,68 +45,50 @@ drive {
 			f: 0
 			percent_tolerance: 1
 		}
-		tolerance_buffer: 25
-		absolute_tolerance: 1
-		minimum_output: 0.1
-		minimum_output_enabled: true
-		maximum_output : 0
-		maximum_output_enabled: false
-		deadband: 0.75
-		deadband_enabled: true
-		inverted: false
-	}
-	straight_PID {
-		PID {
-			p: 0.02
-			i: 0
-			d: 0
-			f: 0
-			percent_tolerance: 1
-		}
-		tolerance_buffer: 25
-		absolute_tolerance: 1
-		minimum_output: 0.1
-		minimum_output_enabled: false
-		maximum_output: 0.33333
-		maximum_output_enabled: true
-		deadband: 0.0
-		deadband_enabled: false
-		max_angular_vel: 1
-		inverted: false
-		drive_straight_delay: 0.25
+        tolerance_buffer: 25
+        absolute_tolerance: 1
+        minimum_output: 0.1
+        minimum_output_enabled: false
+        maximum_output: 0.33333
+        maximum_output_enabled: true
+        deadband: 0.0
+        deadband_enabled: false
+        max_angular_vel: 1
+        inverted: false
+        drive_straight_delay: 0.15
 	}
 	right_master {
-		port: 2
-		feedback_device: QuadEncoder
-		reverse_sensor: false
-		reverse_output: false
-		is_inverted: true
-		nominal_out_voltage: 0.0
-		peak_out_voltage: 12.0
-		profile: 0
-		kP_hg: 0.3
+        port: 8
+        feedback_device: QuadEncoder
+        reverse_sensor: false
+        reverse_output: false
+        is_inverted: true
+        nominal_out_voltage: 0.0
+        peak_out_voltage: 12.0
+        profile: 0
+        kP_hg: 0.3
         kI_hg: 0.00
         kD_hg: 3.0
         kP_mp: 0.2
         kI_mp: 0
         kD_mp: 0
-		max_speed_hg: 12.0127
+        max_speed_hg: 12.0127
         max_speed_lg: 12.0127
-		fwd_lim_norm_open: true
-		rev_lim_norm_open: true
-		fwd_lim_enabled: true
-		rev_lim_enabled: true
-		fwd_soft_lim_enabled: false
-		fwd_soft_lim_val: 0.1
-		rev_soft_lim_enabled: false
-		rev_soft_lim_val: -0.1
-		brake_mode: true
-		encoder_CPR: 512
+        fwd_lim_norm_open: true
+        rev_lim_norm_open: true
+        fwd_lim_enabled: true
+        rev_lim_enabled: true
+        fwd_soft_lim_enabled: false
+        fwd_soft_lim_val: 0.1
+        rev_soft_lim_enabled: false
+        rev_soft_lim_val: -0.1
+        brake_mode: true
+        encoder_CPR: 512
 	}
 	left_master{
         port: 6
         feedback_device: QuadEncoder
-        reverse_sensor: true
+        reverse_sensor: false
         reverse_output: false
         is_inverted: false
         nominal_out_voltage: 0.0
@@ -101,6 +102,114 @@ drive {
         kD_mp: 0.0
         max_speed_hg: 12.0127
         max_speed_lg: 12.0127
+        fwd_lim_norm_open: true
+        rev_lim_norm_open: true
+        fwd_lim_enabled: true
+        rev_lim_enabled: true
+        fwd_soft_lim_enabled: false
+        fwd_soft_lim_val: 0.1
+        rev_soft_lim_enabled: false
+        rev_soft_lim_val: -0.1
+        brake_mode: true
+        encoder_CPR: 512
+    }
+    right_slave {
+        port: 5
+        feedback_device: QuadEncoder
+        reverse_sensor: false
+        reverse_output: false
+        is_inverted: false
+        nominal_out_voltage: 0.0
+        peak_out_voltage: 12.0
+        profile: 0
+        kP_hg: 0.3
+        kI_hg: 0.00
+        kD_hg: 3.0
+        kP_mp: 0.0005
+        kI_mp: 0.1
+        kD_mp: 3.0
+        max_speed_hg: 12.0127
+        fwd_lim_norm_open: true
+        rev_lim_norm_open: true
+        fwd_lim_enabled: true
+        rev_lim_enabled: true
+        fwd_soft_lim_enabled: false
+        fwd_soft_lim_val: 0.1
+        rev_soft_lim_enabled: false
+        rev_soft_lim_val: -0.1
+        brake_mode: true
+        encoder_CPR: 512
+    }
+    right_slave{
+        port: 3
+        feedback_device: QuadEncoder
+        reverse_sensor: false
+        reverse_output: false
+        is_inverted: false
+        nominal_out_voltage: 0.0
+        peak_out_voltage: 12.0
+        profile: 0
+        kP_hg: 0.3
+        kI_hg: 0.00
+        kD_hg: 3.0
+        kP_mp: 0.0005
+        kI_mp: 0.1
+        kD_mp: 3.0
+        max_speed_hg: 12.0127
+        fwd_lim_norm_open: true
+        rev_lim_norm_open: true
+        fwd_lim_enabled: true
+        rev_lim_enabled: true
+        fwd_soft_lim_enabled: false
+        fwd_soft_lim_val: 0.1
+        rev_soft_lim_enabled: false
+        rev_soft_lim_val: -0.1
+        brake_mode: true
+        encoder_CPR: 512
+    }
+    left_slave{
+        port: 1
+        feedback_device: QuadEncoder
+        reverse_sensor: false
+        reverse_output: false
+        is_inverted: false
+        nominal_out_voltage: 0.0
+        peak_out_voltage: 12.0
+        profile: 0
+        kP_hg: 0.3
+        kI_hg: 0.00
+        kD_hg: 3.0
+        kP_mp: 0.0005
+        kI_mp: 0.1
+        kD_mp: 3.0
+        max_speed_hg: 12.0127
+        fwd_lim_norm_open: true
+        rev_lim_norm_open: true
+        fwd_lim_enabled: true
+        rev_lim_enabled: true
+        fwd_soft_lim_enabled: false
+        fwd_soft_lim_val: 0.1
+        rev_soft_lim_enabled: false
+        rev_soft_lim_val: -0.1
+        brake_mode: true
+        encoder_CPR: 512
+    }
+    left_slave{
+        port: 2
+        feedback_device: QuadEncoder
+        reverse_sensor: false
+        reverse_output: false
+        is_inverted: false
+        nominal_out_voltage: 0.0
+        peak_out_voltage: 12.0
+        profile: 0
+        kP_hg: 0.3
+        kI_hg: 0.00
+        kD_hg: 3.0
+        kP_mp: 0.0005
+        kI_mp: 0.1
+        kD_mp: 3.0
+        max_speed_hg: 12.0127
         fwd_lim_norm_open: true
         rev_lim_norm_open: true
         fwd_lim_enabled: true

--- a/src/main/resources/balbasaur_map.cfg
+++ b/src/main/resources/balbasaur_map.cfg
@@ -54,6 +54,7 @@ drive {
 		deadband_enabled: false
 		max_angular_vel: 1
 		inverted: false
+		drive_straight_delay: 0.25
 	}
 	right_master {
 		port: 2

--- a/src/main/resources/fancy_map.cfg
+++ b/src/main/resources/fancy_map.cfg
@@ -112,6 +112,7 @@ drive {
 		deadband_enabled: true
 		max_angular_vel: 0.05
 		inverted: true
+		drive_straight_delay: 0.25
 	}
 	shifter {
 	    forward: 2

--- a/src/main/resources/fancy_map.cfg
+++ b/src/main/resources/fancy_map.cfg
@@ -112,7 +112,7 @@ drive {
 		deadband_enabled: true
 		max_angular_vel: 0.05
 		inverted: true
-		drive_straight_delay: 0.25
+		drive_straight_delay: 0.15
 	}
 	shifter {
 	    forward: 2


### PR DESCRIPTION
Add a delay before switching to driveStraight to give the NavX time to catch up with real life. This should reduce stuttering.